### PR TITLE
Migrate from Laravel Mix to Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
         "css": "npx tailwindcss -i resources/css/app.css --output=public/css/app.css",
         "css:watch": "npx tailwindcss -i resources/css/app.css --output=public/css/app.css --watch",
         "js": "npx esbuild resources/js/app.js --outfile=public/js/app.js --bundle --sourcemap",
-        "js:watch": "npx esbuild resources/js/app.js --outfile=public/js/app.js --bundle --sourcemap --watch"
+        "js:watch": "npx esbuild resources/js/app.js --outfile=public/js/app.js --bundle --sourcemap --watch",
+        "dev": "vite",
+        "build": "vite build"
     },
     "devDependencies": {
         "@alpinejs/collapse": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -1,34 +1,35 @@
 {
-  "private": true,
-  "scripts": {
-    "css": "npx tailwindcss -i resources/css/app.css --output=public/css/app.css",
-    "css:watch": "npx tailwindcss -i resources/css/app.css --output=public/css/app.css --watch",
-    "js": "npx esbuild resources/js/app.js --outfile=public/js/app.js --bundle --sourcemap",
-    "js:watch": "npx esbuild resources/js/app.js --outfile=public/js/app.js --bundle --sourcemap --watch"
-  },
-  "devDependencies": {
-    "@alpinejs/collapse": "^3.9.0",
-    "@alpinejs/intersect": "^3.9.0",
-    "@shufo/prettier-plugin-blade": "^1.0.10",
-    "@tailwindcss/forms": "^0.4.0",
-    "@tailwindcss/line-clamp": "^0.3.1",
-    "@tailwindcss/typography": "^0.5.4",
-    "alpinejs-tmp-alex": "^3.10.3",
-    "autoprefixer": "^10.4.7",
-    "axios": "^0.21",
-    "blade-formatter": "^1.18.6",
-    "browser-sync": "^2.27.7",
-    "browser-sync-webpack-plugin": "^2.3.0",
-    "esbuild": "^0.14.49",
-    "install": "^0.13.0",
-    "laravel-mix": "^6.0.6",
-    "lodash": "^4.17.19",
-    "npm": "^8.5.1",
-    "postcss": "^8.1.14",
-    "postcss-import": "^14.0.1",
-    "prettier-plugin-tailwindcss": "^0.1.7",
-    "tailwindcss": "^3.0.0",
-    "tailwindcss-debug-screens": "^2.2.1",
-    "tippy.js": "^6.3.7"
-  }
+    "private": true,
+    "scripts": {
+        "css": "npx tailwindcss -i resources/css/app.css --output=public/css/app.css",
+        "css:watch": "npx tailwindcss -i resources/css/app.css --output=public/css/app.css --watch",
+        "js": "npx esbuild resources/js/app.js --outfile=public/js/app.js --bundle --sourcemap",
+        "js:watch": "npx esbuild resources/js/app.js --outfile=public/js/app.js --bundle --sourcemap --watch"
+    },
+    "devDependencies": {
+        "@alpinejs/collapse": "^3.9.0",
+        "@alpinejs/intersect": "^3.9.0",
+        "@shufo/prettier-plugin-blade": "^1.0.10",
+        "@tailwindcss/forms": "^0.4.0",
+        "@tailwindcss/line-clamp": "^0.3.1",
+        "@tailwindcss/typography": "^0.5.4",
+        "alpinejs-tmp-alex": "^3.10.3",
+        "autoprefixer": "^10.4.7",
+        "axios": "^0.21",
+        "blade-formatter": "^1.18.6",
+        "browser-sync": "^2.27.7",
+        "browser-sync-webpack-plugin": "^2.3.0",
+        "esbuild": "^0.14.49",
+        "install": "^0.13.0",
+        "lodash": "^4.17.19",
+        "npm": "^8.5.1",
+        "postcss": "^8.1.14",
+        "postcss-import": "^14.0.1",
+        "prettier-plugin-tailwindcss": "^0.1.7",
+        "tailwindcss": "^3.0.0",
+        "tailwindcss-debug-screens": "^2.2.1",
+        "tippy.js": "^6.3.7",
+        "vite": "^3.0.2",
+        "laravel-vite-plugin": "^0.5.0"
+    }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+
+export default defineConfig({
+    plugins: [
+        laravel([
+            'resources/css/app.css',
+            'resources/js/app.js',
+        ]),
+    ],
+});


### PR DESCRIPTION
This pull request includes changes for migrating from Laravel Mix to Vite outlined in [Migration Guide](https://github.com/laravel/vite-plugin/blob/main/UPGRADE.md#migrating-from-laravel-mix-to-vite) and automated by the [Vite Converter](https://laravelshift.com/convert-laravel-mix-to-vite).

**Before merging**, you need to:

- Checkout the `shift-70316` branch
- Run `composer update`
- Run `npm install`
- Review **all** comments for additional changes 
- Thoroughly test your application ([no tests?](https://laravelshift.com/laravel-test-generator), [no CI?](https://laravelshift.com/ci-generator))

Please send your feedback to shift@laravelshift.com or share the good vibes on [Twitter](https://twitter.com/laravelshift).
